### PR TITLE
use correct link to Buildtime Trend dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Code Climate GPA](https://codeclimate.com/github/alxndr/lyrem-ipsum.png)](https://codeclimate.com/github/alxndr/lyrem-ipsum)
 [![dependencies up to date?](https://gemnasium.com/alxndr/lyrem-ipsum.png)](https://gemnasium.com/alxndr/lyrem-ipsum)
 [![test suite status](https://travis-ci.org/alxndr/lyrem-ipsum.png?branch=master)](https://travis-ci.org/alxndr/lyrem-ipsum)
-[![test suite length](https://buildtimetrend.herokuapp.com/badge/buildtimetrend/service/latest)](https://buildtimetrend.herokuapp.com/dashboard/buildtimetrend/service/)
+[![test suite length](https://buildtimetrend.herokuapp.com/badge/alxndr/lyrem-ipsum/latest)](https://buildtimetrend.herokuapp.com/dashboard/alxndr/lyrem-ipsum/)
 [![test coverage status](https://coveralls.io/repos/alxndr/lyrem-ipsum/badge.png)](https://coveralls.io/r/alxndr/lyrem-ipsum)
 [![staging site status](https://codeship.com/projects/139410e0-5a68-0132-efa6-46545b4ba6c4/status)](https://codeship.com/projects/50372)
 


### PR DESCRIPTION
Hi,

Thanks for trying out my project. I hope you like it. Feedback is welcome.

I noticed you copied the link for the badge, without changing the repo name. This PR should fix that.

(I hope to have the [correct URL for shield badges generated](https://github.com/buildtimetrend/python-lib/issues/79) on the website soon, but currently the repo name in the url is fixed)

Kind regards,

Dieter